### PR TITLE
Add icons for linux 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,3 +191,21 @@ qt_add_resources(openscp_hello app_images
 # Ensure predictable in-resource path for the program icon
 set_source_files_properties(assets/program/icon-openscp-2048.png
   PROPERTIES QT_RESOURCE_ALIAS "icon-openscp-2048.png")
+
+if(UNIX) #only linux
+
+set(FILE_DESKTOP
+  assets/linux/openscp.desktop)
+
+set(ICON_DESKTOP_APP
+  assets/program/icon-openscp-2048.png)
+#dont rule install
+install(TARGETS openscp_hello DESTINATION bin)
+#.svg are scalable
+#new folder openscp in share/icons/openscp/scalable/apps  
+install(FILES ${ICON_FILES} DESTINATION share/icons/openscp/scalable/apps)
+#dont good. .png only .svg no mapping .desktop no show. 
+#Change Icon Format SVG
+#install(FILES ${ICON_DESKTOP_APP} DESTINATION share/icons/openscp/hicolor/2048x2048/apps)
+install(FILES ${FILE_DESKTOP} DESTINATION share/applications)
+endif()

--- a/core/include/openscp/SftpClient.hpp
+++ b/core/include/openscp/SftpClient.hpp
@@ -3,6 +3,7 @@
 #pragma once
 #include "SftpTypes.hpp"
 #include <functional>
+#include <memory>
 
 namespace openscp {
 

--- a/ui/MainWindow.hpp
+++ b/ui/MainWindow.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <QPointer>
 #include <memory>
+#include <condition_variable>
 
 class RemoteModel;              // fwd
 class QModelIndex;              // fwd for slot signatures


### PR DESCRIPTION
Los iconos no se muestran en linux porque no se instalan en los directorios del sistema del usuario.
con esta modificacion los iconos se instalan con cmake.

Aque sigue sin mostrar los iconos la app en el entorno snap. pero ya estarian listos para ser leidos por la app. si tiene que hacer modificaciones a .cpp que lee las rutas para que funcione en el entorno linux.