### PR TITLE
new .desktop for snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ AuthKey_*.p8
 
 # macOS
 .DS_Store
+
+#linux
+*.snap
+*.flatpak

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,14 @@ if(UNIX AND NOT APPLE)
   set(APP_ICON_PNG     assets/program/icon-openscp-2048.png)
   set(APP_ICON_NAME    openscp) # must match Icon= in the .desktop
 
+  #folder docs
+  set(DOCS_PATH ${CMAKE_SOURCE_DIR}/docs)
+  file(GLOB_RECURSE DOCS_PATH_FILES "${DOCS_PATH}/*")
+
+  #install files docs
+  install(FILES ${DOCS_PATH_FILES}
+        DESTINATION share/openscp/docs)
+
   # Install binary
   install(TARGETS openscp_hello RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 

--- a/assets/linux/openscp_snap.desktop
+++ b/assets/linux/openscp_snap.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=OpenSCP
+GenericName=SFTP Client
+Comment=Two‑panel SFTP client focused on simplicity and security
+Exec=openscp_hello
+Icon=${SNAP}/usr/share/icons/hicolor/256x256/apps/openscp.png
+Terminal=false
+Categories=Network;FileTransfer;Utility;
+Keywords=SFTP;SSH;File;Transfer;Client;
+StartupWMClass=OpenSCP


### PR DESCRIPTION
Snap no muestra el icono porque se ejecuta en un entorno controlado se requiere una ruta espesifica. Simplemente se creo un nuevo .desktop con la ruta del icono. no requiere modificacion cmake. El archivo se llama en el empaquetado snap.

Los iconos de la app siguen sin mostrarse en la app requiere modificacion al codigo .cpp
si encuentro solucion para el .cpp te mandare el otro pull. 

<img width="1717" height="964" alt="Screenshot From 2025-11-08 11-11-12" src="https://github.com/user-attachments/assets/fd407baa-e1b7-4c4e-8e9b-089b8fbf70cb" />
 

https://github.com/user-attachments/assets/b24d7ed6-3db8-4767-8331-0866a339c5dd

