### PR TITLE
fix(packaging): harden macOS versioning and pkg install flow

### DIFF
--- a/scripts/macos.sh
+++ b/scripts/macos.sh
@@ -53,7 +53,7 @@ resolve_qt_paths() {
   if [[ -n "${QT_PREFIX:-}" ]]; then
     EFFECTIVE_QT_PREFIX="${QT_PREFIX}"
   elif [[ -n "$qt6_dir" && -d "$qt6_dir" ]]; then
-    EFFECTIVE_QT_PREFIX="$(cd "$qt6_dir/../.." && pwd)"
+    EFFECTIVE_QT_PREFIX="$(cd "$qt6_dir/../../.." && pwd)"
   else
     EFFECTIVE_QT_PREFIX=""
   fi


### PR DESCRIPTION
derive artifact version from bundle/CMake and ignore stale APP_VERSION overrides

fix Qt path resolution and prevent pkg installer skip due to relocatable/version checks