### PR TITLE
Error compilation with new version api libsecret

### DIFF
--- a/ui/SecretStore.cpp
+++ b/ui/SecretStore.cpp
@@ -1,5 +1,6 @@
 // SecretStore implementation: Keychain (macOS), Libsecret (Linux), or optional
 // fallback with QSettings.
+#define QT_NO_KEYWORDS // this line for macros break gio macros C
 #include "SecretStore.hpp"
 #include <QByteArray>
 #include <QSettings>
@@ -164,7 +165,11 @@ static const SecretSchema *openscp_schema() {
     static const SecretSchema schema = {
         "openscp.secret",
         SECRET_SCHEMA_NONE,
-        {{"key", SECRET_SCHEMA_ATTRIBUTE_STRING}, {NULL, 0}}};
+        {
+            {"key", SECRET_SCHEMA_ATTRIBUTE_STRING}, 
+            {NULL}
+        }
+    };
     return &schema;
 }
 
@@ -191,7 +196,8 @@ SecretStore::PersistResult SecretStore::setSecret(const QString &key,
 
 std::optional<QString> SecretStore::getSecret(const QString &key) const {
     QByteArray k = key.toUtf8();
-    gchar *pw = secret_password_lookup_sync(openscp_schema(), nullptr, "key",
+    GError *err;
+    gchar *pw = secret_password_lookup_sync(openscp_schema(), nullptr, &err, "key",
                                             k.constData(), nullptr);
     if (!pw)
         return std::nullopt;
@@ -202,7 +208,8 @@ std::optional<QString> SecretStore::getSecret(const QString &key) const {
 
 void SecretStore::removeSecret(const QString &key) {
     QByteArray k = key.toUtf8();
-    (void)secret_password_clear_sync(openscp_schema(), nullptr, "key",
+    GError *error;
+    (void)secret_password_clear_sync(openscp_schema(), nullptr, &error, "key",
                                      k.constData(), nullptr);
 }
 


### PR DESCRIPTION
**Compiler version for flatpak is working**

**file openscp.flatpak is created**

<img width="480" height="270" alt="Screenshot From 2026-02-22 11-27-58" src="https://github.com/user-attachments/assets/88026c6e-89de-45cd-87ce-6e4af0e82495" />

**Flatpak in local is running**

https://github.com/user-attachments/assets/8c3914f9-ae8f-45b5-93f3-4f0222de57c8

#define QT_NO_KEYWORDS is required break code in flatpak dont compile add line and  working

Las modificaciones tienes que agregarlas para que compile en las nuevas versiones de la api de C libsecret que estan disponibles para la compilacion .flatpak y snap. 

Tendrias que probar las modificaciones que hice en tu version. Auque me base en la documentacion oficial [gnome libsecret version 21.3](https://gnome.pages.gitlab.gnome.org/libsecret/func.password_clear_sync.html)

Se le tienen que hacer mas pruebas a la version de flatpak por el momento compila y se ejecuta sin problema. 