### PR TITLE
fix(packaging): bundle missing Qt SVG plugins in release artifacts

### DIFF
--- a/core/src/libssh2/Libssh2SftpClient.cpp
+++ b/core/src/libssh2/Libssh2SftpClient.cpp
@@ -117,6 +117,18 @@ static std::string resolve_posix_home() {
 #endif
 
 // Append host key audit log lines to ~/.openscp/openscp.auth (0600).
+#ifndef _WIN32
+static void write_best_effort(int fd, const char *data, std::size_t len) {
+    while (len > 0) {
+        const ssize_t written = ::write(fd, data, len);
+        if (written <= 0)
+            return;
+        data += (std::size_t)written;
+        len -= (std::size_t)written;
+    }
+}
+#endif
+
 // Best-effort.
 static void auditLogHostKey(const std::string &host, uint16_t port,
                             const std::string &algorithm,
@@ -146,7 +158,7 @@ static void auditLogHostKey(const std::string &host, uint16_t port,
                   (long)time(nullptr), host.c_str(), (unsigned)port,
                   algorithm.c_str(), fingerprint.c_str(),
                   status ? status : "unknown");
-    (void)::write(fd, line, (unsigned)std::strlen(line));
+    write_best_effort(fd, line, std::strlen(line));
     ::close(fd);
 #else
     (void)host;
@@ -1582,7 +1594,7 @@ static bool spawn_ssh_jump_tunnel(const SessionOptions &opt, int &sockOut,
         ::execvp("ssh", argv.data());
         const std::string execErr =
             std::string("exec ssh failed: ") + std::strerror(errno);
-        (void)::write(STDERR_FILENO, execErr.c_str(), execErr.size());
+        write_best_effort(STDERR_FILENO, execErr.c_str(), execErr.size());
         _exit(127);
     }
 

--- a/scripts/package_appimage.sh
+++ b/scripts/package_appimage.sh
@@ -46,6 +46,37 @@ ensure_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "Missing required tool: $1"
 }
 
+detect_qt_plugins_root() {
+  local candidate=""
+
+  if command -v qtpaths6 >/dev/null 2>&1; then
+    candidate="$(qtpaths6 --query QT_INSTALL_PLUGINS 2>/dev/null || true)"
+    [[ -n "$candidate" && -d "$candidate" ]] && { echo "$candidate"; return; }
+  fi
+  if command -v qtpaths >/dev/null 2>&1; then
+    candidate="$(qtpaths --query QT_INSTALL_PLUGINS 2>/dev/null || true)"
+    [[ -n "$candidate" && -d "$candidate" ]] && { echo "$candidate"; return; }
+  fi
+  if command -v qmake6 >/dev/null 2>&1; then
+    candidate="$(qmake6 -query QT_INSTALL_PLUGINS 2>/dev/null || true)"
+    [[ -n "$candidate" && -d "$candidate" ]] && { echo "$candidate"; return; }
+  fi
+  if command -v qmake >/dev/null 2>&1; then
+    candidate="$(qmake -query QT_INSTALL_PLUGINS 2>/dev/null || true)"
+    [[ -n "$candidate" && -d "$candidate" ]] && { echo "$candidate"; return; }
+  fi
+
+  for candidate in \
+    "/usr/lib/qt6/plugins" \
+    "/usr/lib/$(uname -m)-linux-gnu/qt6/plugins" \
+    "/usr/lib64/qt6/plugins"
+  do
+    [[ -d "$candidate" ]] && { echo "$candidate"; return; }
+  done
+
+  return 1
+}
+
 detect_version() {
   local ver
   ver=$(sed -n 's/^project(.*VERSION[[:space:]]*\([0-9][0-9.]*\).*/\1/p' "${REPO_DIR}/CMakeLists.txt" | head -n1 || true)
@@ -137,6 +168,28 @@ verify_svg_plugins() {
   "$checker" --context appimage "$APPDIR"
 }
 
+ensure_qt_svg_iconengine() {
+  local dest_dir="$APPDIR/usr/plugins/iconengines"
+  if compgen -G "$dest_dir/libqsvgicon.so*" >/dev/null 2>&1 || compgen -G "$dest_dir/qsvgicon.so*" >/dev/null 2>&1; then
+    return
+  fi
+
+  local plugin_root=""
+  plugin_root="$(detect_qt_plugins_root || true)"
+  [[ -n "$plugin_root" ]] || die "Could not locate the Qt plugins directory needed to bundle qsvgicon"
+
+  local src_dir="${plugin_root}/iconengines"
+  [[ -d "$src_dir" ]] || die "Qt iconengines directory not found under: $plugin_root"
+
+  local src_plugin=""
+  src_plugin="$(find "$src_dir" -maxdepth 1 \( -type f -o -type l \) \( -name 'libqsvgicon.so*' -o -name 'qsvgicon.so*' \) | head -n1 || true)"
+  [[ -n "$src_plugin" ]] || die "Required Qt icon engine qsvgicon not found in: $src_dir"
+
+  log "Copying required Qt icon engine: $(basename "$src_plugin")"
+  mkdir -p "$dest_dir"
+  cp -L "$src_plugin" "$dest_dir/"
+}
+
 main() {
   mkdir -p "$BUILD_DIR" "$DIST_DIR"
 
@@ -190,6 +243,7 @@ main() {
   cmd+=( --output appimage )
   log "Running: ${cmd[*]}"
   "${cmd[@]}"
+  ensure_qt_svg_iconengine
   verify_svg_plugins
 
   # Rename the produced AppImage to our canonical name if needed

--- a/scripts/package_mac.sh
+++ b/scripts/package_mac.sh
@@ -437,38 +437,84 @@ copy_qt_framework() {
 }
 
 # Ensure Qt image format plugins (e.g., qpng) are present so QPixmap can
-# load PNGs from Qt resources in the About dialog.
-ensure_qt_imageformats() {
-  local dest_dir="$PLUGINS_DIR/imageformats"
-  # If qpng already present, nothing to do
-  if [[ -f "$dest_dir/libqpng.dylib" || -f "$dest_dir/qpng.dylib" ]]; then
-    return
+# load PNGs from Qt resources in the About dialog, and ensure SVG icon engines
+# are bundled for resource/file SVG icons.
+find_qt_plugins_root() {
+  local candidate=""
+  local hbqt=""
+
+  if [[ -n "$QTPREFIX" ]]; then
+    for candidate in \
+      "$QTPREFIX/plugins" \
+      "$QTPREFIX/lib/qt6/plugins" \
+      "$QTPREFIX/share/qt/plugins" \
+      "$QTPREFIX/share/qt6/plugins"
+    do
+      [[ -d "$candidate" ]] && { echo "$candidate"; return; }
+    done
   fi
-  local src=""
-  # Prefer the prefix discovered from macdeployqt
-  if [[ -n "$QTPREFIX" && -d "$QTPREFIX/plugins/imageformats" ]]; then
-    src="$QTPREFIX/plugins/imageformats"
+
+  if command -v qtpaths6 >/dev/null 2>&1; then
+    candidate="$(qtpaths6 --query QT_INSTALL_PLUGINS 2>/dev/null || true)"
+    [[ -n "$candidate" && -d "$candidate" ]] && { echo "$candidate"; return; }
   fi
-  # Fallback: try Homebrew Qt prefix
-  if [[ -z "$src" && $(command -v brew >/dev/null 2>&1; echo $?) -eq 0 ]]; then
-    local hbqt
-    hbqt=$(brew --prefix qt 2>/dev/null || brew --prefix qt@6 2>/dev/null || true)
-    if [[ -n "$hbqt" && -d "$hbqt/plugins/imageformats" ]]; then
-      src="$hbqt/plugins/imageformats"
+  if command -v qtpaths >/dev/null 2>&1; then
+    candidate="$(qtpaths --query QT_INSTALL_PLUGINS 2>/dev/null || true)"
+    [[ -n "$candidate" && -d "$candidate" ]] && { echo "$candidate"; return; }
+  fi
+  if command -v qmake6 >/dev/null 2>&1; then
+    candidate="$(qmake6 -query QT_INSTALL_PLUGINS 2>/dev/null || true)"
+    [[ -n "$candidate" && -d "$candidate" ]] && { echo "$candidate"; return; }
+  fi
+  if command -v qmake >/dev/null 2>&1; then
+    candidate="$(qmake -query QT_INSTALL_PLUGINS 2>/dev/null || true)"
+    [[ -n "$candidate" && -d "$candidate" ]] && { echo "$candidate"; return; }
+  fi
+
+  if command -v brew >/dev/null 2>&1; then
+    hbqt="$(brew --prefix qt 2>/dev/null || brew --prefix qt@6 2>/dev/null || true)"
+    if [[ -n "$hbqt" ]]; then
+      for candidate in \
+        "$hbqt/plugins" \
+        "$hbqt/share/qt/plugins" \
+        "$hbqt/share/qt6/plugins"
+      do
+        [[ -d "$candidate" ]] && { echo "$candidate"; return; }
+      done
     fi
   fi
-  if [[ -n "$src" && -d "$src" ]]; then
-    log "Ensuring Qt imageformats plugins from: $src"
+
+  return 1
+}
+
+ensure_qt_plugin_subdir() {
+  local subdir="$1"
+  local sentinel="$2"
+  local description="$3"
+  local dest_dir="$PLUGINS_DIR/$subdir"
+  if [[ -f "$dest_dir/lib${sentinel}.dylib" || -f "$dest_dir/${sentinel}.dylib" ]]; then
+    return
+  fi
+
+  local plugins_root=""
+  plugins_root="$(find_qt_plugins_root || true)"
+  if [[ -n "$plugins_root" && -d "$plugins_root/$subdir" ]]; then
+    local src="$plugins_root/$subdir"
+    log "Ensuring ${description} plugins from: $src"
     mkdir -p "$dest_dir"
-    # Copy all imageformats to be safe (qpng, qjpeg, etc.)
     if command -v ditto >/dev/null 2>&1; then
       ditto "$src" "$dest_dir"
     else
       cp -R "$src/." "$dest_dir/"
     fi
   else
-    warn "Could not locate Qt imageformats plugins; PNG resources may fail to load"
+    warn "Could not locate ${description} plugins; ${sentinel} may fail to load"
   fi
+}
+
+ensure_qt_support_plugins() {
+  ensure_qt_plugin_subdir "imageformats" "qpng" "Qt imageformats"
+  ensure_qt_plugin_subdir "iconengines" "qsvgicon" "Qt iconengines"
 }
 
 create_dmg() {
@@ -708,8 +754,8 @@ main() {
     fi
   fi
 
-  # Ensure image format plugins (particularly qpng) are present for QPixmap PNGs
-  ensure_qt_imageformats
+  # Ensure image format and SVG icon plugins are present for bundled resources.
+  ensure_qt_support_plugins
 
   # Bundle non-Qt dependencies: libssh2 + OpenSSL (libcrypto)
   log "Bundling non-Qt dependencies"


### PR DESCRIPTION
Copy qsvgicon explicitly for AppImage, harden macOS Qt plugin discovery for imageformats/iconengines, and silence noisy write() warnings in the jump/audit backend path.