### PR TITLE
fix(release): harden macOS and Linux packaging runtime integrity checks

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -159,6 +159,10 @@ jobs:
           CMAKE_OSX_ARCHITECTURES="${{ matrix.arch }}" \
           ./scripts/package_mac.sh
 
+      - name: Verify macOS bundle linkage
+        run: |
+          bash ./scripts/verify_macos_bundle.sh build/OpenSCP.app
+
       - name: Collect macOS artifacts
         run: |
           set -euo pipefail

--- a/scripts/package_appimage.sh
+++ b/scripts/package_appimage.sh
@@ -161,10 +161,10 @@ copy_about_png_fallback() {
   fi
 }
 
-# Validate that Qt SVG plugins are present in the packaged tree.
-verify_svg_plugins() {
+# Validate that Qt runtime plugins and dependencies are present in the packaged tree.
+verify_qt_runtime_plugins() {
   local checker="${REPO_DIR}/scripts/verify_qt_svg_plugins.sh"
-  [[ -x "$checker" ]] || die "SVG plugin checker not found or not executable: $checker"
+  [[ -x "$checker" ]] || die "Qt runtime checker not found or not executable: $checker"
   "$checker" --context appimage "$APPDIR"
 }
 
@@ -244,7 +244,7 @@ main() {
   log "Running: ${cmd[*]}"
   "${cmd[@]}"
   ensure_qt_svg_iconengine
-  verify_svg_plugins
+  verify_qt_runtime_plugins
 
   # Rename the produced AppImage to our canonical name if needed
   local produced

--- a/scripts/package_flatpak.sh
+++ b/scripts/package_flatpak.sh
@@ -59,7 +59,7 @@ uses_external_qt_runtime() {
 main() {
   [[ "$(uname -s)" == "Linux" ]] || die "Flatpak packaging must run on Linux."
   [[ -f "$MANIFEST" ]] || die "Manifest not found: $MANIFEST"
-  [[ -x "$CHECKER" ]] || die "SVG plugin checker not found/executable: $CHECKER"
+  [[ -x "$CHECKER" ]] || die "Qt runtime checker not found/executable: $CHECKER"
 
   ensure_cmd flatpak-builder
   ensure_cmd flatpak
@@ -90,7 +90,7 @@ main() {
     "$build_manifest"
 
   if uses_external_qt_runtime "$build_manifest"; then
-    log "Detected external Flatpak runtime; allowing runtime-provided SVG plugins."
+    log "Detected external Flatpak runtime; allowing runtime-provided Qt plugins."
     "$CHECKER" --allow-runtime-provided --context flatpak "${BUILD_DIR}/files"
   else
     "$CHECKER" --context flatpak "${BUILD_DIR}/files"

--- a/scripts/package_mac.sh
+++ b/scripts/package_mac.sh
@@ -19,6 +19,10 @@ set -euo pipefail
 #   QT_PREFIX              Path to Qt install root (…/Qt/<version>/macos)
 #   Qt6_DIR                Path to Qt6 CMake config dir (…/lib/cmake/Qt6); used to derive Qt bin for macdeployqt
 #   PACKAGE_FORMATS        Comma-separated outputs: app,pkg,dmg (default: dmg)
+#   MACDEPLOYQT_DISABLE_PLUGIN_SCAN
+#                          Set to 1 to pass -no-plugins to macdeployqt.
+#                          Default: 0 (recommended). When disabled, the script
+#                          still stages required plugin families manually.
 #
 # Signing / notarization env vars:
 #   APPLE_IDENTITY         Required for signing, e.g. "Developer ID Application: Your Name (TEAMID)"
@@ -436,8 +440,8 @@ copy_qt_framework() {
   fi
 }
 
-# Ensure Qt runtime plugins are present without relying on macdeployqt's broad
-# plugin scan. We stage only the plugin families the app actually uses.
+# Ensure critical Qt runtime plugin families are present in the bundle.
+# This acts as a safety net on top of what macdeployqt already deploys.
 find_qt_plugins_root() {
   local candidate=""
   local hbqt=""
@@ -729,11 +733,15 @@ main() {
   mqt="$(discover_macdeployqt)"
   log "Running macdeployqt at: $mqt"
   local disable_plugin_scan=0
-  if find_qt_plugins_root >/dev/null 2>&1; then
-    disable_plugin_scan=1
-    log "Using targeted Qt plugin deployment (macdeployqt plugin scan disabled)"
+  if [[ "${MACDEPLOYQT_DISABLE_PLUGIN_SCAN:-0}" == "1" ]]; then
+    if find_qt_plugins_root >/dev/null 2>&1; then
+      disable_plugin_scan=1
+      warn "MACDEPLOYQT_DISABLE_PLUGIN_SCAN=1: disabling macdeployqt plugin scan"
+    else
+      warn "MACDEPLOYQT_DISABLE_PLUGIN_SCAN=1 but Qt plugins root was not found; keeping macdeployqt plugin scan enabled"
+    fi
   else
-    warn "Could not locate a Qt plugins root ahead of macdeployqt; falling back to macdeployqt plugin scanning"
+    log "Using macdeployqt plugin scan (default)"
   fi
   # Build macdeployqt command safely even with set -u and possibly empty extra args
   local libarg=()

--- a/scripts/package_snap.sh
+++ b/scripts/package_snap.sh
@@ -52,7 +52,7 @@ uses_kde_neon_extension() {
 main() {
   [[ "$(uname -s)" == "Linux" ]] || die "Snap packaging must run on Linux."
   [[ -d "$PROJECT_DIR" ]] || die "Snap project directory not found: $PROJECT_DIR"
-  [[ -x "$CHECKER" ]] || die "SVG plugin checker not found/executable: $CHECKER"
+  [[ -x "$CHECKER" ]] || die "Qt runtime checker not found/executable: $CHECKER"
 
   ensure_cmd "$SNAPCRAFT"
   ensure_cmd unsquashfs
@@ -73,10 +73,10 @@ main() {
   tmp_dir="$(mktemp -d)"
   trap '[[ -n "${tmp_dir:-}" ]] && rm -rf "${tmp_dir}"' EXIT
 
-  log "Extracting snap for plugin validation"
+  log "Extracting snap for Qt runtime validation"
   unsquashfs -f -d "${tmp_dir}/root" "${PROJECT_DIR}/$(basename "$snap_file")" >/dev/null
   if uses_kde_neon_extension; then
-    log "Detected kde-neon-6 extension; allowing runtime-provided SVG plugins."
+    log "Detected kde-neon-6 extension; allowing runtime-provided Qt plugins."
     "$CHECKER" --allow-runtime-provided --context snap "${tmp_dir}/root"
   else
     "$CHECKER" --context snap "${tmp_dir}/root"

--- a/scripts/verify_macos_bundle.sh
+++ b/scripts/verify_macos_bundle.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log() { printf "\033[1;34m[verify]\033[0m %s\n" "$*"; }
+err() { printf "\033[1;31m[err ]\033[0m %s\n" "$*" >&2; }
+die() { err "$*"; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/verify_macos_bundle.sh <path-to-OpenSCP.app>
+
+Validates:
+- Required Qt runtime files are present (including qcocoa platform plugin)
+- No dependencies point to Homebrew/runner/local absolute paths
+- @rpath/@loader_path/@executable_path dependencies resolve within the bundle
+EOF
+}
+
+[[ $# -eq 1 ]] || { usage; die "Expected exactly one argument"; }
+
+APP_DIR="$1"
+[[ -d "$APP_DIR" ]] || die "App bundle not found: $APP_DIR"
+
+CONTENTS_DIR="${APP_DIR}/Contents"
+MACOS_DIR="${CONTENTS_DIR}/MacOS"
+FRAMEWORKS_DIR="${CONTENTS_DIR}/Frameworks"
+PLUGINS_DIR="${CONTENTS_DIR}/PlugIns"
+EXE_PATH="${MACOS_DIR}/OpenSCP"
+QT_CONF_PATH="${CONTENTS_DIR}/Resources/qt.conf"
+COCOA_PLUGIN="${PLUGINS_DIR}/platforms/libqcocoa.dylib"
+
+[[ -x "$EXE_PATH" ]] || die "Missing executable: $EXE_PATH"
+[[ -f "$QT_CONF_PATH" ]] || die "Missing qt.conf: $QT_CONF_PATH"
+[[ -f "$COCOA_PLUGIN" ]] || die "Missing Qt cocoa platform plugin: $COCOA_PLUGIN"
+
+require_file() {
+  local file="$1"
+  [[ -e "$file" ]] || die "Missing required bundle file: $file"
+}
+
+require_file "${FRAMEWORKS_DIR}/QtCore.framework/Versions/A/QtCore"
+require_file "${FRAMEWORKS_DIR}/QtGui.framework/Versions/A/QtGui"
+require_file "${FRAMEWORKS_DIR}/QtWidgets.framework/Versions/A/QtWidgets"
+
+path_exists() {
+  local p="$1"
+  if [[ -e "$p" ]]; then
+    return 0
+  fi
+  local dir base
+  dir="$(dirname "$p")"
+  base="$(basename "$p")"
+  (cd "$dir" 2>/dev/null && [[ -e "$(pwd -P)/${base}" ]])
+}
+
+resolve_dep_path() {
+  local dep="$1"
+  local owner="$2"
+  case "$dep" in
+    @rpath/*)
+      printf "%s/%s\n" "$FRAMEWORKS_DIR" "${dep#@rpath/}"
+      ;;
+    @executable_path/*)
+      printf "%s/%s\n" "$MACOS_DIR" "${dep#@executable_path/}"
+      ;;
+    @loader_path/*)
+      local owner_dir
+      owner_dir="$(cd "$(dirname "$owner")" && pwd)"
+      printf "%s/%s\n" "$owner_dir" "${dep#@loader_path/}"
+      ;;
+    *)
+      printf "\n"
+      ;;
+  esac
+}
+
+check_forbidden_absolute_refs() {
+  local file="$1"
+  local forbidden_regex='^/(opt/homebrew|usr/local/(Cellar|opt)|Users/runner|private/tmp|tmp|var/folders|.*miniconda.*|.*anaconda.*)'
+  local deps
+  deps="$(list_deps "$file")"
+  local bad_refs
+  bad_refs="$(printf "%s\n" "$deps" | grep -E "$forbidden_regex" || true)"
+  if [[ -n "$bad_refs" ]]; then
+    err "Forbidden absolute references in: $file"
+    printf "%s\n" "$bad_refs" >&2
+    return 1
+  fi
+  return 0
+}
+
+list_deps() {
+  local file="$1"
+  local out
+  if ! out="$(otool -L "$file" 2>&1)"; then
+    err "$out"
+    die "otool failed for: $file"
+  fi
+  if [[ "$out" == *"You have not agreed to the Xcode license agreements"* ]]; then
+    die "otool is unavailable (Xcode license not accepted); cannot validate $file"
+  fi
+  local deps
+  deps="$(printf "%s\n" "$out" | awk 'NR>1 {print $1}')"
+  [[ -n "$deps" ]] || die "No dependencies were reported by otool for: $file"
+  printf "%s\n" "$deps"
+}
+
+check_linkage() {
+  local file="$1"
+  local deps
+  deps="$(list_deps "$file")"
+  local dep resolved
+  while IFS= read -r dep; do
+    [[ -n "$dep" ]] || continue
+    case "$dep" in
+      /System/*|/usr/lib/*)
+        continue
+        ;;
+      @rpath/*|@executable_path/*|@loader_path/*)
+        resolved="$(resolve_dep_path "$dep" "$file")"
+        if [[ -z "$resolved" ]] || ! path_exists "$resolved"; then
+          die "Unresolved dependency in $(basename "$file"): ${dep} (expected at ${resolved})"
+        fi
+        ;;
+      *)
+        die "Unexpected non-system absolute dependency in $(basename "$file"): ${dep}"
+        ;;
+    esac
+  done <<< "$deps"
+}
+
+targets=("$EXE_PATH")
+while IFS= read -r plugin_dylib; do
+  targets+=("$plugin_dylib")
+done < <(find "$PLUGINS_DIR" -type f -name '*.dylib' | sort)
+
+log "Checking Mach-O linkage for ${#targets[@]} binaries"
+for bin in "${targets[@]}"; do
+  check_forbidden_absolute_refs "$bin"
+  check_linkage "$bin"
+done
+
+log "macOS bundle validation passed: $APP_DIR"

--- a/scripts/verify_qt_svg_plugins.sh
+++ b/scripts/verify_qt_svg_plugins.sh
@@ -13,7 +13,7 @@ Usage:
   verify_qt_svg_plugins.sh [--allow-runtime-provided] [--context <name>] <package-root>
 
 Options:
-  --allow-runtime-provided  Do not fail if qsvg/qsvgicon are missing from package payload.
+  --allow-runtime-provided  Do not fail if qsvg/qsvgicon/qxcb are missing from package payload.
                             Use only when Qt plugins are expected from an external runtime.
   --context <name>          Optional label for diagnostics (e.g. appimage, snap, flatpak).
 EOF
@@ -66,8 +66,20 @@ collect_plugins() {
     | sort -u
 }
 
-mapfile -t svg_plugins < <(collect_plugins qsvg)
-mapfile -t svg_icon_plugins < <(collect_plugins qsvgicon)
+svg_plugins=()
+while IFS= read -r plugin_path; do
+  svg_plugins+=("$plugin_path")
+done < <(collect_plugins qsvg)
+
+svg_icon_plugins=()
+while IFS= read -r plugin_path; do
+  svg_icon_plugins+=("$plugin_path")
+done < <(collect_plugins qsvgicon)
+
+platform_plugins=()
+while IFS= read -r plugin_path; do
+  platform_plugins+=("$plugin_path")
+done < <(collect_plugins qxcb)
 
 missing=()
 if [[ ${#svg_plugins[@]} -eq 0 ]]; then
@@ -75,6 +87,9 @@ if [[ ${#svg_plugins[@]} -eq 0 ]]; then
 fi
 if [[ ${#svg_icon_plugins[@]} -eq 0 ]]; then
   missing+=("qsvgicon (iconengines)")
+fi
+if [[ ${#platform_plugins[@]} -eq 0 ]]; then
+  missing+=("qxcb (platforms)")
 fi
 
 if [[ ${#svg_plugins[@]} -gt 0 ]]; then
@@ -85,16 +100,73 @@ if [[ ${#svg_icon_plugins[@]} -gt 0 ]]; then
   log "Found qsvgicon plugin(s):"
   printf '%s\n' "${svg_icon_plugins[@]}"
 fi
+if [[ ${#platform_plugins[@]} -gt 0 ]]; then
+  log "Found qxcb platform plugin(s):"
+  printf '%s\n' "${platform_plugins[@]}"
+fi
 
 if [[ ${#missing[@]} -eq 0 ]]; then
-  log "Qt SVG plugins validation passed (${CONTEXT})."
-  exit 0
+  log "Qt plugin presence validation passed (${CONTEXT})."
+else
+  if [[ $ALLOW_RUNTIME_PROVIDED -eq 1 ]]; then
+    warn "Missing Qt plugin(s) in payload (${CONTEXT}): ${missing[*]}"
+    warn "Continuing because --allow-runtime-provided is enabled."
+  else
+    die "Missing Qt plugin(s) in payload (${CONTEXT}): ${missing[*]}"
+  fi
 fi
 
 if [[ $ALLOW_RUNTIME_PROVIDED -eq 1 ]]; then
-  warn "Missing Qt SVG plugin(s) in payload (${CONTEXT}): ${missing[*]}"
-  warn "Continuing because --allow-runtime-provided is enabled."
+  warn "Skipping ldd dependency validation because runtime-provided plugins are allowed (${CONTEXT})."
   exit 0
 fi
 
-die "Missing Qt SVG plugin(s) in payload (${CONTEXT}): ${missing[*]}"
+command -v ldd >/dev/null 2>&1 || die "ldd is required for dependency validation (${CONTEXT})."
+command -v file >/dev/null 2>&1 || die "file is required for dependency validation (${CONTEXT})."
+
+declare -a targets
+targets=()
+
+while IFS= read -r exe; do
+  targets+=("$exe")
+done < <(find "$ROOT" -type f -name "openscp_hello" | sort -u)
+
+targets+=("${svg_plugins[@]}")
+targets+=("${svg_icon_plugins[@]}")
+targets+=("${platform_plugins[@]}")
+
+if [[ ${#targets[@]} -eq 0 ]]; then
+  die "No ELF targets found for dependency validation (${CONTEXT})."
+fi
+
+unique_targets=()
+while IFS= read -r target_path; do
+  unique_targets+=("$target_path")
+done < <(printf '%s\n' "${targets[@]}" | awk 'NF' | sort -u)
+
+ldd_failures=0
+for target in "${unique_targets[@]}"; do
+  [[ -e "$target" ]] || continue
+  if ! file -b "$target" | grep -q "ELF"; then
+    continue
+  fi
+
+  ldd_out="$(ldd "$target" 2>&1 || true)"
+  if [[ -z "$ldd_out" ]]; then
+    warn "ldd produced no output for: $target"
+    continue
+  fi
+
+  missing_lines="$(printf '%s\n' "$ldd_out" | grep -F "not found" || true)"
+  if [[ -n "$missing_lines" ]]; then
+    err "Missing shared libraries for: $target"
+    printf '%s\n' "$missing_lines"
+    ldd_failures=1
+  fi
+done
+
+if [[ $ldd_failures -ne 0 ]]; then
+  die "Dependency validation failed (${CONTEXT})."
+fi
+
+log "Qt runtime dependency validation passed (${CONTEXT})."


### PR DESCRIPTION
- fix(packaging): prevent Qt runtime plugin regressions across macOS and Linux artifacts
- ci(release): add bundle/runtime validation for macOS and Linux deliverables
- fix(build): stabilize unsigned macOS artifacts and Linux Qt plugin validation