### PR TITLE
fix(ui): harden remote session recovery and release 0.8.1 updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(OpenSCP_hello LANGUAGES CXX VERSION 0.8.0)
+project(OpenSCP_hello LANGUAGES CXX VERSION 0.8.1)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ open build/OpenSCP.app
 - Main status bar emits transfer completion notices (for successful uploads/downloads).
 - Transfers use interruptible worker sessions and bounded socket read/write waits to avoid indefinite hangs during stalled network conditions.
 - Upload completion path is hardened and remote views refresh reliably after finished uploads.
+- Critical remote operations now attempt one automatic stale-session recovery (reconnect + retry) before failing.
+- Main remote session health checks run periodically and after wake/resume; if transport is no longer valid, OpenSCP disconnects safely with a clear warning.
 
 ### 3. SFTP security hardening
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cmake --build build -j
 open build/OpenSCP.app
 ```
 
-## What OpenSCP Offers (v0.8.0)
+## What OpenSCP Offers (v0.8.1)
 
 ### 1. Dual-panel workflow
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -66,6 +66,8 @@ open build/OpenSCP.app
 - La barra de estado principal muestra avisos de transferencias completadas (subidas/descargas exitosas).
 - Las transferencias usan sesiones de worker interrumpibles y tiempos de espera acotados de lectura/escritura en socket para evitar bloqueos indefinidos cuando la red se estanca.
 - El flujo de finalizacion de subidas esta endurecido y las vistas remotas se refrescan de forma confiable al terminar uploads.
+- Las operaciones remotas criticas ahora intentan una recuperacion automatica de sesion stale (reconexion + reintento) antes de fallar.
+- La sesion remota principal se valida de forma periodica y al volver de suspension/bloqueo; si el transporte ya no es valido, OpenSCP se desconecta de forma segura con aviso claro.
 
 ### 3. Endurecimiento de seguridad SFTP
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -44,7 +44,7 @@ cmake --build build -j
 open build/OpenSCP.app
 ```
 
-## Lo que Ofrece OpenSCP (v0.8.0)
+## Lo que Ofrece OpenSCP (v0.8.1)
 
 ### 1. Flujo de doble panel
 

--- a/assets/macos/Info.plist.in
+++ b/assets/macos/Info.plist.in
@@ -18,8 +18,8 @@
     @EXECUTABLE_NAME@         e.g. OpenSCP
     @ICON_FILE@               e.g. OpenSCP (no .icns extension)
     @MINIMUM_SYSTEM_VERSION@  e.g. 12.0
-    @VERSION_SHORT@           e.g. 0.8.0
-    @VERSION@                 e.g. 0.8.0 (or build number)
+    @VERSION_SHORT@           e.g. 0.8.1
+    @VERSION@                 e.g. 0.8.1 (or build number)
     @CURRENT_YEAR@            e.g. 2025
 -->
 <dict>

--- a/core/src/libssh2/Libssh2SftpClient.cpp
+++ b/core/src/libssh2/Libssh2SftpClient.cpp
@@ -1078,9 +1078,12 @@ static bool line_matches_site_host(const std::string &line,
         if (comma == std::string::npos || comma > hostEnd)
             comma = hostEnd;
         const std::string token = line.substr(pos, comma - pos);
-        for (const std::string &target : targets) {
-            if (token == target || token_matches_hashed_host(token, target))
-                return true;
+        if (std::any_of(targets.begin(), targets.end(),
+                        [&token](const std::string &target) {
+                            return token == target ||
+                                   token_matches_hashed_host(token, target);
+                        })) {
+            return true;
         }
         if (comma == hostEnd)
             break;
@@ -1588,8 +1591,10 @@ static bool spawn_ssh_jump_tunnel(const SessionOptions &opt, int &sockOut,
 
         std::vector<char *> argv;
         argv.reserve(args.size() + 1);
-        for (auto &a : args)
-            argv.push_back(const_cast<char *>(a.c_str()));
+        std::transform(args.begin(), args.end(), std::back_inserter(argv),
+                       [](const std::string &a) {
+                           return const_cast<char *>(a.c_str());
+                       });
         argv.push_back(nullptr);
         ::execvp("ssh", argv.data());
         const std::string execErr =

--- a/packaging/snap/snapcraft.yaml
+++ b/packaging/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: openscp
 base: core24
-version: "0.8.0"
+version: "0.8.1"
 summary: Two-panel SFTP client focused on simplicity and security
 description: |
   Two-panel SFTP client focused on simplicity and security

--- a/scripts/generate_release_notes.sh
+++ b/scripts/generate_release_notes.sh
@@ -8,7 +8,7 @@ Usage:
   scripts/generate_release_notes.sh --tag <tag> [options]
 
 Options:
-  --tag <tag>          Tag to generate notes for (e.g. v0.8.0). Required.
+  --tag <tag>          Tag to generate notes for (e.g. v0.8.1). Required.
   --version <version>  Version label to show in notes (default: tag without leading v).
   --repo <owner/repo>  GitHub repository for compare links (optional).
   --range <A..B>       Explicit git range. If omitted, uses previous tag..tag.

--- a/translations/openscp_es.ts
+++ b/translations/openscp_es.ts
@@ -1400,6 +1400,102 @@ Edita el sitio y deja solo un transporte.</translation>
         <source>Drop ignored: remote-origin drag cannot be dropped back into the same remote panel</source>
         <translation>Soltado ignorado: el arrastre de origen remoto no puede soltarse de nuevo en el mismo panel remoto</translation>
     </message>
+    <message>
+        <source>No active remote session to reconnect.</source>
+        <translation>No hay sesión remota activa para reconectar.</translation>
+    </message>
+    <message>
+        <source>Connection state is changing; reconnect skipped.</source>
+        <translation>El estado de la conexión está cambiando; se omitió la reconexión.</translation>
+    </message>
+    <message>
+        <source>Reconnect already in progress.</source>
+        <translation>Ya hay una reconexión en progreso.</translation>
+    </message>
+    <message>
+        <source>Remote session became stale. Reconnecting…</source>
+        <translation>La sesión remota quedó obsoleta. Reconectando…</translation>
+    </message>
+    <message>
+        <source>Reconnected transport, but remote panel restore failed.</source>
+        <translation>Se reconectó el transporte, pero falló restaurar el panel remoto.</translation>
+    </message>
+    <message>
+        <source>Remote session reconnected</source>
+        <translation>Sesión remota reconectada</translation>
+    </message>
+    <message>
+        <source>Recovered remote session while trying to %1</source>
+        <translation>Se recuperó la sesión remota al intentar %1</translation>
+    </message>
+    <message>
+        <source>Invalid operation callback</source>
+        <translation>Callback de operación inválido</translation>
+    </message>
+    <message>
+        <source>No active remote session</source>
+        <translation>No hay sesión remota activa</translation>
+    </message>
+    <message>
+        <source>The remote session failed while trying to %1.
+OpenSCP will disconnect to avoid inconsistent operations.
+%2</source>
+        <translation>La sesión remota falló al intentar %1.
+OpenSCP se desconectará para evitar operaciones inconsistentes.
+%2</translation>
+    </message>
+    <message>
+        <source>validate the remote session</source>
+        <translation>validar la sesión remota</translation>
+    </message>
+    <message>
+        <source>periodic</source>
+        <translation>periódica</translation>
+    </message>
+    <message>
+        <source>resume (%1s)</source>
+        <translation>reanudación (%1s)</translation>
+    </message>
+    <message>
+        <source>Remote session validated (%1)</source>
+        <translation>Sesión remota validada (%1)</translation>
+    </message>
+    <message>
+        <source>The remote session no longer responds (%1).
+OpenSCP will disconnect to avoid inconsistent operations.
+%2</source>
+        <translation>La sesión remota dejó de responder (%1).
+OpenSCP se desconectará para evitar operaciones inconsistentes.
+%2</translation>
+    </message>
+    <message>
+        <source>create a remote folder</source>
+        <translation>crear una carpeta remota</translation>
+    </message>
+    <message>
+        <source>check remote item existence</source>
+        <translation>comprobar existencia del elemento remoto</translation>
+    </message>
+    <message>
+        <source>create a remote file</source>
+        <translation>crear un archivo remoto</translation>
+    </message>
+    <message>
+        <source>rename a remote item</source>
+        <translation>renombrar un elemento remoto</translation>
+    </message>
+    <message>
+        <source>delete remote items</source>
+        <translation>eliminar elementos remotos</translation>
+    </message>
+    <message>
+        <source>read remote permissions</source>
+        <translation>leer permisos remotos</translation>
+    </message>
+    <message>
+        <source>change remote permissions</source>
+        <translation>cambiar permisos remotos</translation>
+    </message>
 </context>
 <context>
     <name>PermissionsDialog</name>

--- a/translations/openscp_pt.ts
+++ b/translations/openscp_pt.ts
@@ -1400,6 +1400,102 @@ Edite o site e mantenha apenas um transporte.</translation>
         <source>Drop ignored: remote-origin drag cannot be dropped back into the same remote panel</source>
         <translation>Soltar ignorado: arrasto de origem remota não pode ser solto novamente no mesmo painel remoto</translation>
     </message>
+    <message>
+        <source>No active remote session to reconnect.</source>
+        <translation>Não há sessão remota ativa para reconectar.</translation>
+    </message>
+    <message>
+        <source>Connection state is changing; reconnect skipped.</source>
+        <translation>O estado da conexão está mudando; reconexão ignorada.</translation>
+    </message>
+    <message>
+        <source>Reconnect already in progress.</source>
+        <translation>Já existe uma reconexão em andamento.</translation>
+    </message>
+    <message>
+        <source>Remote session became stale. Reconnecting…</source>
+        <translation>A sessão remota ficou obsoleta. Reconectando…</translation>
+    </message>
+    <message>
+        <source>Reconnected transport, but remote panel restore failed.</source>
+        <translation>O transporte foi reconectado, mas a restauração do painel remoto falhou.</translation>
+    </message>
+    <message>
+        <source>Remote session reconnected</source>
+        <translation>Sessão remota reconectada</translation>
+    </message>
+    <message>
+        <source>Recovered remote session while trying to %1</source>
+        <translation>Sessão remota recuperada ao tentar %1</translation>
+    </message>
+    <message>
+        <source>Invalid operation callback</source>
+        <translation>Callback de operação inválido</translation>
+    </message>
+    <message>
+        <source>No active remote session</source>
+        <translation>Não há sessão remota ativa</translation>
+    </message>
+    <message>
+        <source>The remote session failed while trying to %1.
+OpenSCP will disconnect to avoid inconsistent operations.
+%2</source>
+        <translation>A sessão remota falhou ao tentar %1.
+O OpenSCP vai desconectar para evitar operações inconsistentes.
+%2</translation>
+    </message>
+    <message>
+        <source>validate the remote session</source>
+        <translation>validar a sessão remota</translation>
+    </message>
+    <message>
+        <source>periodic</source>
+        <translation>periódica</translation>
+    </message>
+    <message>
+        <source>resume (%1s)</source>
+        <translation>retomada (%1s)</translation>
+    </message>
+    <message>
+        <source>Remote session validated (%1)</source>
+        <translation>Sessão remota validada (%1)</translation>
+    </message>
+    <message>
+        <source>The remote session no longer responds (%1).
+OpenSCP will disconnect to avoid inconsistent operations.
+%2</source>
+        <translation>A sessão remota não responde mais (%1).
+O OpenSCP vai desconectar para evitar operações inconsistentes.
+%2</translation>
+    </message>
+    <message>
+        <source>create a remote folder</source>
+        <translation>criar uma pasta remota</translation>
+    </message>
+    <message>
+        <source>check remote item existence</source>
+        <translation>verificar existência do item remoto</translation>
+    </message>
+    <message>
+        <source>create a remote file</source>
+        <translation>criar um arquivo remoto</translation>
+    </message>
+    <message>
+        <source>rename a remote item</source>
+        <translation>renomear um item remoto</translation>
+    </message>
+    <message>
+        <source>delete remote items</source>
+        <translation>excluir itens remotos</translation>
+    </message>
+    <message>
+        <source>read remote permissions</source>
+        <translation>ler permissões remotas</translation>
+    </message>
+    <message>
+        <source>change remote permissions</source>
+        <translation>alterar permissões remotas</translation>
+    </message>
 </context>
 <context>
     <name>PermissionsDialog</name>

--- a/ui/MainWindow.hpp
+++ b/ui/MainWindow.hpp
@@ -12,6 +12,7 @@
 #include <QVector>
 #include <atomic>
 #include <condition_variable>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -239,6 +240,20 @@ class MainWindow : public QMainWindow {
     bool restoreRightHeaderState(bool remoteMode);
     void maybeRefreshRemoteAfterCompletedUploads();
     void maybeNotifyCompletedTransfers();
+    bool isLikelyRemoteTransportError(const QString &rawError) const;
+    bool reconnectActiveRemoteSession(QString *errorOut = nullptr);
+    bool maybeRecoverRemoteSession(const QString &operationLabel,
+                                   const QString &rawError);
+    bool executeCriticalRemoteOperation(
+        const QString &operationLabel,
+        const std::function<bool(openscp::SftpClient *, std::string &)>
+            &operation,
+        std::string &err);
+    void ensureRemoteSessionHealthMonitoring();
+    void startRemoteSessionHealthMonitoring();
+    void stopRemoteSessionHealthMonitoring();
+    void runRemoteSessionHealthCheck(const QString &reason,
+                                     bool force = false);
 
     // Writable state of the current remote directory
     bool rightRemoteWritable_ = false;
@@ -287,8 +302,13 @@ class MainWindow : public QMainWindow {
     QLabel *m_connectionTypeLabel_ = nullptr;
     QLabel *m_connectionElapsedLabel_ = nullptr;
     QTimer *m_connectionElapsedTimer_ = nullptr;
+    QTimer *m_remoteSessionHealthTimer_ = nullptr;
     qint64 m_connectionStartedAtMs_ = 0;
     QString m_activeConnectionType_;
+    qint64 m_lastAppInactiveAtMs_ = 0;
+    std::atomic<bool> m_remoteSessionHealthProbeInFlight_{false};
+    std::atomic<bool> m_remoteSessionReconnectInFlight_{false};
+    int m_remoteSessionHealthIntervalMs_ = 10 * 60 * 1000;
     // Connection progress dialog (non-modal), to avoid blocking TOFU
     QPointer<class QProgressDialog> m_connectProgress_;
     bool m_connectProgressDimmed_ = false;

--- a/ui/MainWindowConnection.cpp
+++ b/ui/MainWindowConnection.cpp
@@ -14,6 +14,7 @@
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDir>
+#include <QGuiApplication>
 #include <QHeaderView>
 #include <QInputDialog>
 #include <QLabel>
@@ -23,6 +24,7 @@
 #include <QProgressDialog>
 #include <QSet>
 #include <QSettings>
+#include <QStringList>
 #include <QStandardPaths>
 #include <QStatusBar>
 #include <QTimer>
@@ -377,6 +379,269 @@ static void refreshOpenSiteManagerWidget(QPointer<QWidget> siteManager) {
     dlg->reloadFromSettings();
 }
 
+bool MainWindow::isLikelyRemoteTransportError(const QString &rawError) const {
+    const QString lower = rawError.trimmed().toLower();
+    if (lower.isEmpty())
+        return false;
+
+    // Permission/auth/path problems should not trigger reconnect logic.
+    if (lower.contains("permission denied") || lower.contains("read-only") ||
+        lower.contains("no such file") || lower.contains("not found") ||
+        lower.contains("auth fail") || lower.contains("authentication failed"))
+        return false;
+
+    static const QStringList markers = {
+        QStringLiteral("socket send"),
+        QStringLiteral("socket recv"),
+        QStringLiteral("socket error"),
+        QStringLiteral("session disconnected"),
+        QStringLiteral("channel closed"),
+        QStringLiteral("connection lost"),
+        QStringLiteral("connection reset"),
+        QStringLiteral("connection aborted"),
+        QStringLiteral("broken pipe"),
+        QStringLiteral("transport endpoint is not connected"),
+        QStringLiteral("end of file"),
+        QStringLiteral("timeout"),
+        QStringLiteral("timed out"),
+        QStringLiteral("rc=-7"),  // LIBSSH2_ERROR_SOCKET_SEND
+        QStringLiteral("rc=-34"), // LIBSSH2_ERROR_SOCKET_RECV
+        QStringLiteral("rc=-37"), // LIBSSH2_ERROR_CHANNEL_CLOSED
+        QStringLiteral("rc=-13"), // LIBSSH2_ERROR_SOCKET_DISCONNECT
+    };
+    for (const QString &marker : markers) {
+        if (lower.contains(marker))
+            return true;
+    }
+    return false;
+}
+
+bool MainWindow::reconnectActiveRemoteSession(QString *errorOut) {
+    if (errorOut)
+        errorOut->clear();
+    if (!rightIsRemote_ || !sftp_ || !m_activeSessionOptions_.has_value()) {
+        if (errorOut)
+            *errorOut = tr("No active remote session to reconnect.");
+        return false;
+    }
+    if (m_isDisconnecting || m_connectInProgress_) {
+        if (errorOut)
+            *errorOut = tr("Connection state is changing; reconnect skipped.");
+        return false;
+    }
+    if (m_remoteSessionReconnectInFlight_.exchange(true)) {
+        if (errorOut)
+            *errorOut = tr("Reconnect already in progress.");
+        return false;
+    }
+
+    const QString restorePath =
+        rightRemoteModel_ ? rightRemoteModel_->rootPath() : QStringLiteral("/");
+    statusBar()->showMessage(tr("Remote session became stale. Reconnecting…"),
+                             0);
+
+    std::string connErr;
+    auto replacement = sftp_->newConnectionLike(*m_activeSessionOptions_, connErr);
+    if (!replacement) {
+        m_remoteSessionReconnectInFlight_.store(false);
+        if (errorOut)
+            *errorOut = QString::fromStdString(connErr);
+        return false;
+    }
+
+    sftp_->disconnect();
+    sftp_ = std::move(replacement);
+    applyRemoteConnectedUI(*m_activeSessionOptions_);
+    if (!sftp_ || !rightRemoteModel_) {
+        m_remoteSessionReconnectInFlight_.store(false);
+        if (errorOut) {
+            *errorOut = tr("Reconnected transport, but remote panel restore "
+                           "failed.");
+        }
+        return false;
+    }
+
+    if (!restorePath.isEmpty() && restorePath != QStringLiteral("/"))
+        setRightRemoteRoot(restorePath);
+
+    if (transferMgr_) {
+        transferMgr_->setClient(sftp_.get());
+        transferMgr_->setSessionOptions(*m_activeSessionOptions_);
+    }
+
+    startRemoteSessionHealthMonitoring();
+    statusBar()->showMessage(tr("Remote session reconnected"), 4000);
+    m_remoteSessionReconnectInFlight_.store(false);
+    return true;
+}
+
+bool MainWindow::maybeRecoverRemoteSession(const QString &operationLabel,
+                                           const QString &rawError) {
+    if (!isLikelyRemoteTransportError(rawError))
+        return false;
+
+    QString reconnectErr;
+    const bool recovered = reconnectActiveRemoteSession(&reconnectErr);
+    if (recovered) {
+        statusBar()->showMessage(
+            tr("Recovered remote session while trying to %1")
+                .arg(operationLabel),
+            4000);
+        return true;
+    }
+    return false;
+}
+
+bool MainWindow::executeCriticalRemoteOperation(
+    const QString &operationLabel,
+    const std::function<bool(openscp::SftpClient *, std::string &)> &operation,
+    std::string &err) {
+    err.clear();
+    if (!operation) {
+        err = "Invalid operation callback";
+        return false;
+    }
+    if (!rightIsRemote_ || !sftp_) {
+        err = "No active remote session";
+        return false;
+    }
+
+    if (operation(sftp_.get(), err))
+        return true;
+
+    const QString firstError = QString::fromStdString(err);
+    if (!maybeRecoverRemoteSession(operationLabel, firstError)) {
+        if (isLikelyRemoteTransportError(firstError) && rightIsRemote_ &&
+            sftp_ && !m_isDisconnecting) {
+            UiAlerts::warning(
+                this, tr("Connection lost"),
+                tr("The remote session failed while trying to %1.\n"
+                   "OpenSCP will disconnect to avoid inconsistent operations.\n%2")
+                    .arg(operationLabel,
+                         shortRemoteError(firstError, tr("Transport error."))));
+            disconnectSftp();
+        }
+        return false;
+    }
+
+    err.clear();
+    if (!sftp_) {
+        err = "Remote session unavailable after recovery";
+        return false;
+    }
+    return operation(sftp_.get(), err);
+}
+
+void MainWindow::ensureRemoteSessionHealthMonitoring() {
+    if (m_remoteSessionHealthTimer_)
+        return;
+
+    m_remoteSessionHealthTimer_ = new QTimer(this);
+    m_remoteSessionHealthTimer_->setSingleShot(false);
+    m_remoteSessionHealthTimer_->setInterval(m_remoteSessionHealthIntervalMs_);
+    connect(m_remoteSessionHealthTimer_, &QTimer::timeout, this, [this] {
+        runRemoteSessionHealthCheck(tr("periodic"), false);
+    });
+
+    auto *guiApp = qobject_cast<QGuiApplication *>(QCoreApplication::instance());
+    if (!guiApp)
+        return;
+    connect(guiApp, &QGuiApplication::applicationStateChanged, this,
+            [this](Qt::ApplicationState state) {
+                const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+                if (state == Qt::ApplicationActive) {
+                    if (m_lastAppInactiveAtMs_ <= 0) {
+                        m_lastAppInactiveAtMs_ = 0;
+                        return;
+                    }
+                    const qint64 inactiveMs = nowMs - m_lastAppInactiveAtMs_;
+                    m_lastAppInactiveAtMs_ = 0;
+                    constexpr qint64 kResumeProbeThresholdMs = 60 * 1000;
+                    if (inactiveMs >= kResumeProbeThresholdMs && rightIsRemote_ &&
+                        sftp_) {
+                        runRemoteSessionHealthCheck(
+                            tr("resume (%1s)").arg(inactiveMs / 1000), true);
+                    }
+                    return;
+                }
+                m_lastAppInactiveAtMs_ = nowMs;
+            });
+}
+
+void MainWindow::startRemoteSessionHealthMonitoring() {
+    if (!rightIsRemote_ || !sftp_)
+        return;
+    ensureRemoteSessionHealthMonitoring();
+    if (!m_remoteSessionHealthTimer_)
+        return;
+    if (m_remoteSessionHealthIntervalMs_ < 60000)
+        m_remoteSessionHealthIntervalMs_ = 60000;
+    m_remoteSessionHealthTimer_->setInterval(m_remoteSessionHealthIntervalMs_);
+    m_remoteSessionHealthProbeInFlight_.store(false);
+    m_lastAppInactiveAtMs_ = 0;
+    if (!m_remoteSessionHealthTimer_->isActive())
+        m_remoteSessionHealthTimer_->start();
+}
+
+void MainWindow::stopRemoteSessionHealthMonitoring() {
+    if (m_remoteSessionHealthTimer_)
+        m_remoteSessionHealthTimer_->stop();
+    m_remoteSessionHealthProbeInFlight_.store(false);
+    m_remoteSessionReconnectInFlight_.store(false);
+    m_lastAppInactiveAtMs_ = 0;
+}
+
+void MainWindow::runRemoteSessionHealthCheck(const QString &reason, bool force) {
+    if (!rightIsRemote_ || !sftp_ || !m_activeSessionOptions_.has_value())
+        return;
+    if (m_isDisconnecting || m_connectInProgress_)
+        return;
+    bool expected = false;
+    if (!m_remoteSessionHealthProbeInFlight_.compare_exchange_strong(expected,
+                                                                     true)) {
+        return;
+    }
+
+    const QString probePath =
+        (rightRemoteModel_ && !rightRemoteModel_->rootPath().isEmpty())
+            ? rightRemoteModel_->rootPath()
+            : QStringLiteral("/");
+    std::string err;
+    bool isDir = false;
+    const bool ok = executeCriticalRemoteOperation(
+        tr("validate the remote session"),
+        [probePath, &isDir](openscp::SftpClient *client, std::string &opErr) {
+            bool exists = false;
+            exists = client->exists(probePath.toStdString(), isDir, opErr);
+            if (exists)
+                return true;
+            return opErr.empty();
+        },
+        err);
+    m_remoteSessionHealthProbeInFlight_.store(false);
+    if (ok) {
+        if (force && !reason.isEmpty()) {
+            statusBar()->showMessage(tr("Remote session validated (%1)")
+                                         .arg(reason),
+                                     2500);
+        }
+        return;
+    }
+    if (!rightIsRemote_ || !sftp_ || m_isDisconnecting)
+        return;
+
+    const QString rawErr = QString::fromStdString(err);
+    if (!isLikelyRemoteTransportError(rawErr))
+        return;
+
+    UiAlerts::warning(
+        this, tr("Connection lost"),
+        tr("The remote session no longer responds (%1).\n"
+           "OpenSCP will disconnect to avoid inconsistent operations.\n%2")
+            .arg(reason, shortRemoteError(rawErr, tr("Transport error."))));
+    disconnectSftp();
+}
+
 void MainWindow::connectSftp() {
     ConnectionDialog dlg(this);
     dlg.setQuickConnectSaveOptionsVisible(true);
@@ -432,6 +697,7 @@ void MainWindow::disconnectSftp() {
     if (m_isDisconnecting)
         return;
     m_isDisconnecting = true;
+    stopRemoteSessionHealthMonitoring();
     const quint64 disconnectSeq = ++m_disconnectSeq_;
     m_transferCleanupInProgress_ = (transferMgr_ != nullptr);
     m_transferCleanupStartedAtMs_ =
@@ -1356,7 +1622,7 @@ void MainWindow::maybePersistQuickConnectSite(
 
 // Switch UI into remote mode and wire models/actions for the right pane.
 void MainWindow::applyRemoteConnectedUI(const openscp::SessionOptions &opt) {
-    saveRightHeaderState(false);
+    saveRightHeaderState(rightIsRemote_);
     delete rightRemoteModel_;
     rightRemoteModel_ = new RemoteModel(sftp_.get(), this);
     rightRemoteModel_->setSessionOptions(opt);
@@ -1388,12 +1654,58 @@ void MainWindow::applyRemoteConnectedUI(const openscp::SessionOptions &opt) {
                 .arg(shortRemoteError(e,
                                       tr("Failed to read remote contents."))));
         sftp_.reset();
+        rightView_->setModel(rightLocalModel_);
         m_remoteWriteabilityCache_.clear();
         m_activeSessionOptions_.reset();
         m_sessionNoHostVerification_ = false;
+        rightIsRemote_ = false;
+        stopRemoteSessionHealthMonitoring();
+        if (transferMgr_)
+            transferMgr_->setClient(nullptr);
         updateHostPolicyRiskBanner();
         delete rightRemoteModel_;
         rightRemoteModel_ = nullptr;
+        if (actConnect_)
+            actConnect_->setEnabled(true);
+        if (actDisconnect_)
+            actDisconnect_->setEnabled(false);
+        if (actDownloadF7_)
+            actDownloadF7_->setEnabled(false);
+        if (actUploadRight_)
+            actUploadRight_->setEnabled(false);
+        if (actRefreshRight_)
+            actRefreshRight_->setEnabled(false);
+        if (actNewDirRight_)
+            actNewDirRight_->setEnabled(true);
+        if (actNewFileRight_)
+            actNewFileRight_->setEnabled(true);
+        if (actRenameRight_)
+            actRenameRight_->setEnabled(true);
+        if (actDeleteRight_)
+            actDeleteRight_->setEnabled(true);
+        if (actMoveRight_)
+            actMoveRight_->setEnabled(true);
+        if (actMoveRightTb_)
+            actMoveRightTb_->setEnabled(true);
+        if (actCopyRightTb_)
+            actCopyRightTb_->setEnabled(true);
+        if (actChooseRight_) {
+            actChooseRight_->setIcon(
+                QIcon(QLatin1String(":/assets/icons/action-open-folder.svg")));
+            actChooseRight_->setEnabled(true);
+            actChooseRight_->setToolTip(actChooseRight_->text());
+        }
+        if (QDir(rightPath_->text()).exists()) {
+            setRightRoot(rightPath_->text());
+        } else {
+            setRightRoot(QDir::homePath());
+        }
+        if (rightView_)
+            rightView_->setEnabled(true);
+        rightRemoteWritable_ = false;
+        applyRemoteWriteabilityActions();
+        updateDeleteShortcutEnables();
+        setWindowTitle(tr("OpenSCP — local/local"));
         return;
     }
     rightView_->setModel(rightRemoteModel_);
@@ -1455,6 +1767,7 @@ void MainWindow::applyRemoteConnectedUI(const openscp::SessionOptions &opt) {
         tr("Connected (SFTP) to ") + QString::fromStdString(opt.host), 4000);
     setWindowTitle(tr("OpenSCP — local/remote (SFTP)"));
     updateHostPolicyRiskBanner();
+    startRemoteSessionHealthMonitoring();
     updateRemoteWriteability();
     updateDeleteShortcutEnables();
 }

--- a/ui/MainWindowRemoteOps.cpp
+++ b/ui/MainWindowRemoteOps.cpp
@@ -858,7 +858,13 @@ void MainWindow::newDirRight() {
         const QString path =
             joinRemotePath(rightRemoteModel_->rootPath(), name);
         std::string err;
-        if (!sftp_->mkdir(path.toStdString(), err, 0755)) {
+        const bool okMkdir = executeCriticalRemoteOperation(
+            tr("create a remote folder"),
+            [path](openscp::SftpClient *client, std::string &opErr) {
+                return client->mkdir(path.toStdString(), opErr, 0755);
+            },
+            err);
+        if (!okMkdir) {
             invalidateRemoteWriteabilityFromError(QString::fromStdString(err));
             UiAlerts::critical(
                 this, tr("SFTP"),
@@ -898,21 +904,32 @@ void MainWindow::newFileRight() {
         const QString remotePath =
             joinRemotePath(rightRemoteModel_->rootPath(), name);
         bool isDir = false;
+        bool exists = false;
         std::string e;
-        bool exists = sftp_->exists(remotePath.toStdString(), isDir, e);
-        if (exists) {
-            if (UiAlerts::question(
-                    this, tr("File exists"),
-                    tr("«%1» already exists.\nOverwrite?").arg(name),
-                    QMessageBox::Yes | QMessageBox::No) != QMessageBox::Yes)
-                return;
-        } else if (!e.empty()) {
+        const bool existsCheckOk = executeCriticalRemoteOperation(
+            tr("check remote item existence"),
+            [remotePath, &isDir,
+             &exists](openscp::SftpClient *client, std::string &opErr) {
+                exists = client->exists(remotePath.toStdString(), isDir, opErr);
+                if (exists)
+                    return true;
+                return opErr.empty();
+            },
+            e);
+        if (!existsCheckOk) {
             UiAlerts::critical(
                 this, tr("SFTP"),
                 tr("Could not check whether the remote file already "
                    "exists.\n%1")
                     .arg(shortRemoteError(e, tr("Remote error"))));
             return;
+        }
+        if (exists) {
+            if (UiAlerts::question(
+                    this, tr("File exists"),
+                    tr("«%1» already exists.\nOverwrite?").arg(name),
+                    QMessageBox::Yes | QMessageBox::No) != QMessageBox::Yes)
+                return;
         }
 
         QTemporaryFile tmp;
@@ -923,8 +940,14 @@ void MainWindow::newFileRight() {
         }
         tmp.close();
         std::string err;
-        bool okPut = sftp_->put(tmp.fileName().toStdString(),
-                                remotePath.toStdString(), err);
+        const bool okPut = executeCriticalRemoteOperation(
+            tr("create a remote file"),
+            [tmpPath = tmp.fileName(),
+             remotePath](openscp::SftpClient *client, std::string &opErr) {
+                return client->put(tmpPath.toStdString(), remotePath.toStdString(),
+                                   opErr);
+            },
+            err);
         if (!okPut) {
             invalidateRemoteWriteabilityFromError(QString::fromStdString(err));
             UiAlerts::critical(
@@ -985,7 +1008,14 @@ void MainWindow::renameRightSelected() {
         const QString from = joinRemotePath(base, oldName);
         const QString to = joinRemotePath(base, newName);
         std::string err;
-        if (!sftp_->rename(from.toStdString(), to.toStdString(), err, false)) {
+        const bool okRename = executeCriticalRemoteOperation(
+            tr("rename a remote item"),
+            [from, to](openscp::SftpClient *client, std::string &opErr) {
+                return client->rename(from.toStdString(), to.toStdString(),
+                                      opErr, false);
+            },
+            err);
+        if (!okRename) {
             invalidateRemoteWriteabilityFromError(QString::fromStdString(err));
             UiAlerts::critical(
                 this, tr("SFTP"),
@@ -1039,20 +1069,41 @@ void MainWindow::deleteRightSelected() {
         int ok = 0, fail = 0;
         QString lastErr;
         const QString base = rightRemoteModel_->rootPath();
+        QStringList names;
+        names.reserve(rows.size());
+        for (const QModelIndex &idx : rows)
+            names.push_back(rightRemoteModel_->nameAt(idx));
         std::function<bool(const QString &)> delRec = [&](const QString &p) {
             // Determine if path is a directory or a file using stat/exists
             bool isDir = false;
+            bool exists = false;
             std::string xerr;
-            if (!sftp_->exists(p.toStdString(), isDir, xerr)) {
-                // If it doesn't exist, treat as success
-                if (xerr.empty())
-                    return true;
+            const bool existsOk = executeCriticalRemoteOperation(
+                tr("delete remote items"),
+                [p, &isDir,
+                 &exists](openscp::SftpClient *client, std::string &opErr) {
+                    exists = client->exists(p.toStdString(), isDir, opErr);
+                    if (exists)
+                        return true;
+                    // Not found is not an error in delete flow.
+                    return opErr.empty();
+                },
+                xerr);
+            if (!existsOk) {
                 lastErr = QString::fromStdString(xerr);
                 return false;
             }
+            if (!exists)
+                return true;
             if (!isDir) {
                 std::string ferr;
-                if (!sftp_->removeFile(p.toStdString(), ferr)) {
+                const bool removed = executeCriticalRemoteOperation(
+                    tr("delete remote items"),
+                    [p](openscp::SftpClient *client, std::string &opErr) {
+                        return client->removeFile(p.toStdString(), opErr);
+                    },
+                    ferr);
+                if (!removed) {
                     lastErr = QString::fromStdString(ferr);
                     return false;
                 }
@@ -1061,7 +1112,14 @@ void MainWindow::deleteRightSelected() {
             // Directory: list and remove children first (depth-first)
             std::vector<openscp::FileInfo> out;
             std::string lerr;
-            if (!sftp_->list(p.toStdString(), out, lerr)) {
+            const bool listed = executeCriticalRemoteOperation(
+                tr("delete remote items"),
+                [p, &out](openscp::SftpClient *client, std::string &opErr) {
+                    out.clear();
+                    return client->list(p.toStdString(), out, opErr);
+                },
+                lerr);
+            if (!listed) {
                 lastErr = QString::fromStdString(lerr);
                 return false;
             }
@@ -1072,14 +1130,19 @@ void MainWindow::deleteRightSelected() {
                     return false;
             }
             std::string derr;
-            if (!sftp_->removeDir(p.toStdString(), derr)) {
+            const bool removedDir = executeCriticalRemoteOperation(
+                tr("delete remote items"),
+                [p](openscp::SftpClient *client, std::string &opErr) {
+                    return client->removeDir(p.toStdString(), opErr);
+                },
+                derr);
+            if (!removedDir) {
                 lastErr = QString::fromStdString(derr);
                 return false;
             }
             return true;
         };
-        for (const QModelIndex &idx : rows) {
-            const QString name = rightRemoteModel_->nameAt(idx);
+        for (const QString &name : names) {
             const QString path = joinRemotePath(base, name);
             if (delRec(path))
                 ++ok;
@@ -1234,7 +1297,13 @@ void MainWindow::changeRemotePermissions() {
     const QString path = joinRemotePath(base, name);
     openscp::FileInfo st{};
     std::string err;
-    if (!sftp_->stat(path.toStdString(), st, err)) {
+    const bool statOk = executeCriticalRemoteOperation(
+        tr("read remote permissions"),
+        [path, &st](openscp::SftpClient *client, std::string &opErr) {
+            return client->stat(path.toStdString(), st, opErr);
+        },
+        err);
+    if (!statOk) {
         UiAlerts::warning(
             this, tr("Permissions"),
             tr("Could not read permissions.\n%1")
@@ -1249,7 +1318,13 @@ void MainWindow::changeRemotePermissions() {
     unsigned int newMode = (st.mode & ~0777u) | (dlg.mode() & 0777u);
     auto applyOne = [&](const QString &p) -> bool {
         std::string cerrs;
-        if (!sftp_->chmod(p.toStdString(), newMode, cerrs)) {
+        const bool chmodOk = executeCriticalRemoteOperation(
+            tr("change remote permissions"),
+            [p, newMode](openscp::SftpClient *client, std::string &opErr) {
+                return client->chmod(p.toStdString(), newMode, opErr);
+            },
+            cerrs);
+        if (!chmodOk) {
             invalidateRemoteWriteabilityFromError(
                 QString::fromStdString(cerrs));
             const QString item =
@@ -1276,7 +1351,14 @@ void MainWindow::changeRemotePermissions() {
             }
             std::vector<openscp::FileInfo> out;
             std::string lerr;
-            if (!sftp_->list(cur.toStdString(), out, lerr))
+            const bool listed = executeCriticalRemoteOperation(
+                tr("read remote permissions"),
+                [cur, &out](openscp::SftpClient *client, std::string &opErr) {
+                    out.clear();
+                    return client->list(cur.toStdString(), out, opErr);
+                },
+                lerr);
+            if (!listed)
                 continue;
             for (const auto &e : out) {
                 const QString child =


### PR DESCRIPTION
## Summary
This PR consolidates the latest 5 commits into the 0.8.1 update focused on remote-session reliability and release polish.

## Changes included
- Bumped app version to `0.8.1`.
- Added automatic stale-session recovery for critical remote operations:
  - reconnect + retry flow for transport-level failures.
  - safer disconnect behavior when recovery is not possible.
- Added remote session health monitoring:
  - periodic validation.
  - validation after app resume/wake.
- Updated i18n resources:
  - new strings translated for Spanish (`es`) and Portuguese (`pt`).
- Updated docs:
  - `README.md` and `README_ES.md` now reflect current behavior/features.
- Fixed Nightly Quality cppcheck.