### PR TITLE
fix(packaging): stabilize macOS runtime and improve Linux visual integration

### DIFF
--- a/scripts/macos.sh
+++ b/scripts/macos.sh
@@ -9,7 +9,49 @@ EFFECTIVE_QT6_DIR=""
 EFFECTIVE_QT_PREFIX=""
 
 log() { printf "\033[1;34m[macos]\033[0m %s\n" "$*"; }
+warn() { printf "\033[1;33m[warn]\033[0m %s\n" "$*"; }
 die() { printf "\033[1;31m[err ]\033[0m %s\n" "$*"; exit 1; }
+
+list_rpaths() {
+  local bin="$1"
+  otool -l "$bin" | awk '
+    $1 == "cmd" && $2 == "LC_RPATH" { in_rpath=1; next }
+    in_rpath && $1 == "path" { print $2; in_rpath=0 }
+  '
+}
+
+sanitize_dev_rpaths() {
+  local bin="$1"
+  local bundled_rpath='@executable_path/../Frameworks'
+  local qt_lib_rpath=""
+  if [[ -d "${EFFECTIVE_QT_PREFIX}/lib" ]]; then
+    qt_lib_rpath="${EFFECTIVE_QT_PREFIX}/lib"
+  fi
+
+  local rp=""
+  while IFS= read -r rp; do
+    [[ -n "$rp" ]] || continue
+    case "$rp" in
+      "$bundled_rpath"|@executable_path/*|@loader_path/*|@rpath/*)
+        ;;
+      "$qt_lib_rpath")
+        ;;
+      /*)
+        # Remove stale absolute build paths to keep dev launches relocatable.
+        install_name_tool -delete_rpath "$rp" "$bin" >/dev/null 2>&1 || true
+        ;;
+      *)
+        ;;
+    esac
+  done < <(list_rpaths "$bin")
+
+  if ! list_rpaths "$bin" | grep -Fxq "$bundled_rpath"; then
+    install_name_tool -add_rpath "$bundled_rpath" "$bin" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$qt_lib_rpath" ]] && ! list_rpaths "$bin" | grep -Fxq "$qt_lib_rpath"; then
+    install_name_tool -add_rpath "$qt_lib_rpath" "$bin" >/dev/null 2>&1 || true
+  fi
+}
 
 version_key() {
   local v="${1:-0}"
@@ -121,20 +163,30 @@ build_release() {
 
 run_app() {
   [[ -d "$APP_PATH" ]] || die "App bundle not found at ${APP_PATH}. Run './scripts/macos.sh build' first."
-  log "Opening ${APP_PATH}"
-  if ! open "$APP_PATH"; then
-    local bin="${APP_PATH}/Contents/MacOS/OpenSCP"
-    [[ -x "$bin" ]] || die "Cannot launch app: missing executable at ${bin}"
-    log "LaunchServices open() failed; running binary directly with Qt env"
-    if [[ -d "${EFFECTIVE_QT_PREFIX}/lib" ]]; then
-      QT_PLUGIN_PATH="${EFFECTIVE_QT_PREFIX}/plugins" \
-      QML2_IMPORT_PATH="${EFFECTIVE_QT_PREFIX}/qml" \
-      DYLD_FRAMEWORK_PATH="${EFFECTIVE_QT_PREFIX}/lib" \
-      DYLD_LIBRARY_PATH="${EFFECTIVE_QT_PREFIX}/lib" \
-      nohup "$bin" >/dev/null 2>&1 &
-    else
-      nohup "$bin" >/dev/null 2>&1 &
+  local bin="${APP_PATH}/Contents/MacOS/OpenSCP"
+  [[ -x "$bin" ]] || die "Cannot launch app: missing executable at ${bin}"
+  sanitize_dev_rpaths "$bin"
+
+  local bundled_qt_widgets="${APP_PATH}/Contents/Frameworks/QtWidgets.framework/Versions/A/QtWidgets"
+  if [[ -f "$bundled_qt_widgets" ]]; then
+    log "Opening ${APP_PATH}"
+    if open "$APP_PATH"; then
+      return
     fi
+    warn "LaunchServices open() failed; falling back to direct binary launch"
+  else
+    warn "Dev bundle has no bundled Qt frameworks; launching with Qt runtime env"
+  fi
+
+  if [[ -d "${EFFECTIVE_QT_PREFIX}/lib" ]]; then
+    QT_PLUGIN_PATH="${EFFECTIVE_QT_PREFIX}/plugins" \
+    QML2_IMPORT_PATH="${EFFECTIVE_QT_PREFIX}/qml" \
+    DYLD_FRAMEWORK_PATH="${EFFECTIVE_QT_PREFIX}/lib" \
+    DYLD_LIBRARY_PATH="${EFFECTIVE_QT_PREFIX}/lib" \
+    nohup "$bin" >/dev/null 2>&1 &
+  else
+    warn "Qt runtime prefix was not detected; launching without Qt env overrides"
+    nohup "$bin" >/dev/null 2>&1 &
   fi
 }
 

--- a/scripts/package_appimage.sh
+++ b/scripts/package_appimage.sh
@@ -190,6 +190,42 @@ ensure_qt_svg_iconengine() {
   cp -L "$src_plugin" "$dest_dir/"
 }
 
+copy_optional_qt_plugin() {
+  local plugin_root="$1"
+  local subdir="$2"
+  local plugin_name="$3"
+  local dest_dir="$APPDIR/usr/plugins/$subdir"
+  local src_dir="${plugin_root}/${subdir}"
+
+  [[ -d "$src_dir" ]] || return 0
+
+  if compgen -G "$dest_dir/lib${plugin_name}.so*" >/dev/null 2>&1 || compgen -G "$dest_dir/${plugin_name}.so*" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local src_plugin=""
+  src_plugin="$(find "$src_dir" -maxdepth 1 \( -type f -o -type l \) \( -name "lib${plugin_name}.so*" -o -name "${plugin_name}.so*" \) | head -n1 || true)"
+  [[ -n "$src_plugin" ]] || return 0
+
+  mkdir -p "$dest_dir"
+  cp -L "$src_plugin" "$dest_dir/"
+  log "Copying optional Qt ${subdir} plugin: $(basename "$src_plugin")"
+}
+
+ensure_optional_qt_desktop_theme_plugins() {
+  local plugin_root=""
+  plugin_root="$(detect_qt_plugins_root || true)"
+  if [[ -z "$plugin_root" ]]; then
+    warn "Could not detect Qt plugins root for optional desktop theme plugins"
+    return 0
+  fi
+
+  # Keep Linux look closer to host desktop theme when these plugins are available.
+  copy_optional_qt_plugin "$plugin_root" "styles" "qgtk3"
+  copy_optional_qt_plugin "$plugin_root" "platformthemes" "qgtk3"
+  copy_optional_qt_plugin "$plugin_root" "platformthemes" "qxdgdesktopportal"
+}
+
 main() {
   mkdir -p "$BUILD_DIR" "$DIST_DIR"
 
@@ -244,6 +280,7 @@ main() {
   log "Running: ${cmd[*]}"
   "${cmd[@]}"
   ensure_qt_svg_iconengine
+  ensure_optional_qt_desktop_theme_plugins
   verify_qt_runtime_plugins
 
   # Rename the produced AppImage to our canonical name if needed

--- a/scripts/package_mac.sh
+++ b/scripts/package_mac.sh
@@ -248,11 +248,41 @@ generate_icns_from_png() {
   rm -rf "$(dirname "$tmp_iconset")"
 }
 
-ensure_rpath() {
-  local bin="$1"; local rpath='@executable_path/../Frameworks'
-  if ! otool -l "$bin" | grep -q "$rpath"; then
-    install_name_tool -add_rpath "$rpath" "$bin"
+list_binary_rpaths() {
+  local bin="$1"
+  otool -l "$bin" | awk '
+    $1 == "cmd" && $2 == "LC_RPATH" { in_rpath=1; next }
+    in_rpath && $1 == "path" { print $2; in_rpath=0 }
+  '
+}
+
+sanitize_binary_rpaths() {
+  local bin="$1"
+  local required_rpath="$2"
+  local existing_rpath=""
+
+  while IFS= read -r existing_rpath; do
+    [[ -n "$existing_rpath" ]] || continue
+    case "$existing_rpath" in
+      "$required_rpath"|@executable_path/*|@loader_path/*|@rpath/*)
+        ;;
+      /*)
+        # Strip absolute rpaths so the bundle can be relocated.
+        install_name_tool -delete_rpath "$existing_rpath" "$bin" >/dev/null 2>&1 || true
+        ;;
+      *)
+        ;;
+    esac
+  done < <(list_binary_rpaths "$bin")
+
+  if ! list_binary_rpaths "$bin" | grep -Fxq "$required_rpath"; then
+    install_name_tool -add_rpath "$required_rpath" "$bin" || true
   fi
+}
+
+ensure_rpath() {
+  local bin="$1"
+  sanitize_binary_rpaths "$bin" "@executable_path/../Frameworks"
 }
 
 redirect_dep_to_rpath() {
@@ -280,10 +310,7 @@ qt_framework_dep_to_bundle_rpath() {
 
 ensure_loader_framework_rpath() {
   local bin="$1"
-  local rpath='@loader_path/../../Frameworks'
-  if ! otool -l "$bin" | grep -q "$rpath"; then
-    install_name_tool -add_rpath "$rpath" "$bin" || true
-  fi
+  sanitize_binary_rpaths "$bin" "@loader_path/../../Frameworks"
 }
 
 rewrite_external_refs_to_bundle() {
@@ -674,6 +701,7 @@ ensure_qt_support_plugins() {
   ensure_qt_plugin_subdir "platforms" "qcocoa" "Qt platform"
   ensure_qt_plugin_subdir "imageformats" "qsvg" "Qt imageformats" 0
   ensure_qt_plugin_subdir "iconengines" "qsvgicon" "Qt iconengines"
+  ensure_qt_plugin_subdir "styles" "qmacstyle" "Qt macOS style" 0
 }
 
 prune_optional_qt_plugins() {

--- a/scripts/verify_macos_bundle.sh
+++ b/scripts/verify_macos_bundle.sh
@@ -77,7 +77,7 @@ resolve_dep_path() {
 
 check_forbidden_absolute_refs() {
   local file="$1"
-  local forbidden_regex='^/(opt/homebrew|usr/local/(Cellar|opt)|Users/runner|private/tmp|tmp|var/folders|.*miniconda.*|.*anaconda.*)'
+  local forbidden_regex='^/(opt/homebrew|usr/local/(Cellar|opt)|Users/runner|Users/|private/tmp|tmp|var/folders|.*miniconda.*|.*anaconda.*)'
   local deps
   deps="$(list_deps "$file")"
   local bad_refs
@@ -85,6 +85,37 @@ check_forbidden_absolute_refs() {
   if [[ -n "$bad_refs" ]]; then
     err "Forbidden absolute references in: $file"
     printf "%s\n" "$bad_refs" >&2
+    return 1
+  fi
+  return 0
+}
+
+list_rpaths() {
+  local file="$1"
+  local out
+  if ! out="$(otool -l "$file" 2>&1)"; then
+    err "$out"
+    die "otool failed while listing rpaths for: $file"
+  fi
+  if [[ "$out" == *"You have not agreed to the Xcode license agreements"* ]]; then
+    die "otool is unavailable (Xcode license not accepted); cannot validate rpaths for $file"
+  fi
+  printf "%s\n" "$out" | awk '
+    $1 == "cmd" && $2 == "LC_RPATH" { in_rpath=1; next }
+    in_rpath && $1 == "path" { print $2; in_rpath=0 }
+  '
+}
+
+check_forbidden_rpaths() {
+  local file="$1"
+  local forbidden_regex='^/(opt/homebrew|usr/local/(Cellar|opt)|Users/runner|Users/|private/tmp|tmp|var/folders|.*miniconda.*|.*anaconda.*)'
+  local rpaths
+  rpaths="$(list_rpaths "$file")"
+  local bad_rpaths
+  bad_rpaths="$(printf "%s\n" "$rpaths" | grep -E "$forbidden_regex" || true)"
+  if [[ -n "$bad_rpaths" ]]; then
+    err "Forbidden absolute rpath(s) in: $file"
+    printf "%s\n" "$bad_rpaths" >&2
     return 1
   fi
   return 0
@@ -138,6 +169,7 @@ done < <(find "$PLUGINS_DIR" -type f -name '*.dylib' | sort)
 log "Checking Mach-O linkage for ${#targets[@]} binaries"
 for bin in "${targets[@]}"; do
   check_forbidden_absolute_refs "$bin"
+  check_forbidden_rpaths "$bin"
   check_linkage "$bin"
 done
 


### PR DESCRIPTION
## Summary

This PR bundles 3 related packaging/runtime improvements:

1. More robust `macos dev` launch flow:
- Sanitizes stale `rpath` entries before launching.
- Falls back to direct launch with Qt runtime env vars when the dev bundle has no embedded Qt frameworks, preventing `dyld` startup crashes.

2. Stronger macOS packaging/verification:
- Sanitizes absolute `rpath` entries in bundled binaries/plugins.
- Extends `verify_macos_bundle.sh` to fail on forbidden absolute `rpath` values.
- Tries to include optional `qmacstyle` for a more native macOS look and feel.

3. Better Linux AppImage desktop integration:
- Copies optional desktop theme/style plugins when available (`qgtk3`, `qxdgdesktopportal`) to improve host desktop visual consistency.